### PR TITLE
Fix configuration on mapreduce job

### DIFF
--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/mapper/HadoopSegmentCreationMapReduceJob.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/mapper/HadoopSegmentCreationMapReduceJob.java
@@ -138,12 +138,12 @@ public class HadoopSegmentCreationMapReduceJob {
       }
 
       context.write(new LongWritable(Long.parseLong(lineSplits[2])),
-          new Text(FileSystem.get(new Configuration()).listStatus(new Path(_localHdfsSegmentTarPath + "/"))[0].getPath().getName()));
+          new Text(FileSystem.get(_properties).listStatus(new Path(_localHdfsSegmentTarPath + "/"))[0].getPath().getName()));
       LOGGER.info("finished the job successfully");
     }
 
     private String createSegment(String dataFilePath, Schema schema, String seqId) throws Exception {
-      final FileSystem fs = FileSystem.get(new Configuration());
+      final FileSystem fs = FileSystem.get(_properties);
       final Path hdfsDataPath = new Path(dataFilePath);
       final File dataPath = new File(_currentDiskWorkDir, "data");
       if (dataPath.exists()) {


### PR DESCRIPTION
I got following "Wrong FS" errors, when I run SegmentCreation job with pinot-hadoop.
It seems `new Configuration()` loads only empty `core-site.xml` file, and loads `fs.defaultFS` value as `file:///` in the MR job.
It will be fixed using `context.getProperty()` in the job.
Mapper would be better to use JobConf from their context.

Similar issue as #63.

----
Error on the map task log:
```
2017-01-17 11:32:02,718 ERROR [main] com.linkedin.pinot.hadoop.job.mapper.HadoopSegmentCreationMapReduceJob$HadoopSegmentCreationMapper: Got exceptions during creating segments!
java.lang.IllegalArgumentException: Wrong FS: hdfs://<HOSTNAME>:8020/user/pinot/input/data/part-2.avro, expected: file:///
	at org.apache.hadoop.fs.FileSystem.checkPath(FileSystem.java:661)
	at org.apache.hadoop.fs.RawLocalFileSystem.pathToFile(RawLocalFileSystem.java:87)
	at org.apache.hadoop.fs.RawLocalFileSystem.deprecatedGetFileStatus(RawLocalFileSystem.java:619)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileLinkStatusInternal(RawLocalFileSystem.java:850)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileStatus(RawLocalFileSystem.java:614)
	at org.apache.hadoop.fs.FilterFileSystem.getFileStatus(FilterFileSystem.java:422)
	at org.apache.hadoop.fs.FileUtil.copy(FileUtil.java:340)
	at org.apache.hadoop.fs.FileUtil.copy(FileUtil.java:292)
	at org.apache.hadoop.fs.LocalFileSystem.copyToLocalFile(LocalFileSystem.java:88)
	at org.apache.hadoop.fs.FileSystem.copyToLocalFile(FileSystem.java:1996)
	at com.linkedin.pinot.hadoop.job.mapper.HadoopSegmentCreationMapReduceJob$HadoopSegmentCreationMapper.createSegment(HadoopSegmentCreationMapReduceJob.java:154)
	at com.linkedin.pinot.hadoop.job.mapper.HadoopSegmentCreationMapReduceJob$HadoopSegmentCreationMapper.map(HadoopSegmentCreationMapReduceJob.java:134)
	at com.linkedin.pinot.hadoop.job.mapper.HadoopSegmentCreationMapReduceJob$HadoopSegmentCreationMapper.map(HadoopSegmentCreationMapReduceJob.java:44)
	at org.apache.hadoop.mapreduce.Mapper.run(Mapper.java:146)
	at org.apache.hadoop.mapred.MapTask.runNewMapper(MapTask.java:787)
	at org.apache.hadoop.mapred.MapTask.run(MapTask.java:341)
	at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:168)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1724)
	at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:162)
```